### PR TITLE
Add modern color animations to the main headline.

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,7 +150,15 @@
             line-height: 1.2;
             margin-bottom: 1rem;
             position: relative;
-            color: rgba(255, 255, 255, 0.8);
+            /* color: rgba(255, 255, 255, 0.8); Original color, will be handled by animation */
+            animation: colorCycle 15s infinite linear;
+        }
+
+        @keyframes colorCycle {
+            0% { color: #e0e0e0; } /* Similar to original */
+            33% { color: var(--accent-color); }
+            66% { color: #c0c0ff; } /* Light lavender */
+            100% { color: #e0e0e0; }
         }
 
         .main-headline .glow-span {
@@ -164,12 +172,18 @@
             -webkit-background-clip: text;
             background-clip: text;
             color: transparent;
-            opacity: 0;
-            transition: opacity 0.3s;
+            opacity: 1; /* Changed from 0 to 1 */
+            /* transition: opacity 0.3s; Removed */
+            animation: pulsatingGlow 3s infinite ease-in-out;
         }
 
-        .main-headline:hover .glow-span {
+        /* .main-headline:hover .glow-span { Removed, opacity is now always 1
             opacity: 1;
+        } */
+
+        @keyframes pulsatingGlow {
+            0%, 100% { transform: scale(1); opacity: 0.7; }
+            50% { transform: scale(1.05); opacity: 1; }
         }
 
         .sub-headline {


### PR DESCRIPTION
This commit introduces two new CSS animations to the main headline:

1.  A color cycle animation (`colorCycle`) for the main text of `.main-headline`, slowly transitioning through a set of modern, harmonious colors (#e0e0e0, accent-color, light lavender) over 15 seconds.
2.  A pulsating glow animation (`pulsatingGlow`) for the `.glow-span` element, providing a continuous, subtle pulse effect (3s duration, ease-in-out timing).

The previous hover-only glow effect was changed to be always active and integrated into the new pulsating animation. These changes aim to enhance the visual appeal of the title with dynamic, modern effects.